### PR TITLE
Add three extra tags

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Admin User Message ===
 Contributors:      jonathanbardo
-Tags:              admin, message
+Tags:              admin, message, messages, admin message, admin messages
 Requires at least: 4.2
 Tested up to:      4.4
 Stable tag:        trunk


### PR DESCRIPTION
These tags are used by other similar plugins, so it'd be good to have this plugin show up along with them when people search these tags. For example: https://wordpress.org/plugins/tags/admin-message

I've included the plurals as well, as it seems to be what lots of plugins do.
